### PR TITLE
Fix gob.Register

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"encoding/gob"
+	"image"
 	"image/color"
 	"sort"
 	"strings"
@@ -8,6 +10,10 @@ import (
 	"github.com/sago35/tinydisplay/defines"
 	"tinygo.org/x/drivers/touch"
 )
+
+func init() {
+	gob.Register(&image.RGBA{})
+}
 
 type Server struct {
 	Device *Device


### PR DESCRIPTION
This PR corrects the following errors

```
$ go run ./examples/basic/
panic: gob: name not registered for interface: "*image.RGBA"

goroutine 35 [running]:
github.com/sago35/tinydisplay.(*Client).update(0x0?)
        /home/sago35/dev/src/github.com/sago35/tinydisplay/client.go:144 +0xd3
github.com/sago35/tinydisplay.(*Client).Tick(0xc000200300)
        /home/sago35/dev/src/github.com/sago35/tinydisplay/client.go:48 +0x5b
created by github.com/sago35/tinydisplay.NewClient
        /home/sago35/dev/src/github.com/sago35/tinydisplay/client.go:41 +0x1a5
exit status 2
```